### PR TITLE
feat: add accountInfo request to retrieve account details

### DIFF
--- a/packages/client/src/connectors/leather.ts
+++ b/packages/client/src/connectors/leather.ts
@@ -101,6 +101,17 @@ export function leather(parameters: UTXOConnectorParameters = {}) {
           }
           return signedPsbt
         }
+        case 'addressInfo': {
+          const accounts: GetAccountsResponse =
+            await this.request('getAddresses')
+          if (!accounts.result) {
+            throw new UserRejectedRequestError({
+              name: UserRejectedRequestError.name,
+              message: accounts.error?.message!,
+            })
+          }
+          return accounts.result.addresses
+        }
         default:
           throw new MethodNotSupportedRpcError(
             new Error(MethodNotSupportedRpcError.name),
@@ -148,7 +159,8 @@ export function leather(parameters: UTXOConnectorParameters = {}) {
       if (!provider) {
         throw new ProviderNotFoundError()
       }
-      const accounts = await provider.request('getAddresses')
+      const accounts: GetAccountsResponse =
+        await provider.request('getAddresses')
       if (!accounts.result) {
         throw new UserRejectedRequestError({
           name: UserRejectedRequestError.name,

--- a/packages/client/src/connectors/phantom.ts
+++ b/packages/client/src/connectors/phantom.ts
@@ -105,6 +105,10 @@ export function phantom(parameters: UTXOConnectorParameters = {}) {
           ).join('')
           return signedPsbtHex
         }
+        case 'addressInfo': {
+          const accounts: BtcAccount[] = await this.requestAccounts()
+          return accounts.filter((account) => account.purpose === 'payment')
+        }
         default:
           throw new MethodNotSupportedRpcError(
             new Error(MethodNotSupportedRpcError.name),
@@ -164,7 +168,7 @@ export function phantom(parameters: UTXOConnectorParameters = {}) {
       if (!provider) {
         throw new ProviderNotFoundError()
       }
-      const accounts = await provider.requestAccounts()
+      const accounts: BtcAccount[] = await provider.requestAccounts()
       return accounts
         .filter((account) => account.purpose === 'payment')
         .map((account) => account.address as Address)

--- a/packages/client/src/connectors/xverse.ts
+++ b/packages/client/src/connectors/xverse.ts
@@ -141,6 +141,21 @@ export function xverse(parameters: UTXOConnectorParameters = {}) {
           }
           return signedPsbt
         }
+        case 'addressInfo': {
+          const accounts: GetAccountsResponse = await this.request(
+            'getAddresses',
+            {
+              purposes: ['payment'],
+            }
+          )
+          if (!accounts.result) {
+            throw new UserRejectedRequestError({
+              name: UserRejectedRequestError.name,
+              message: accounts.error?.message!,
+            })
+          }
+          return accounts.result.addresses
+        }
         default:
           throw new MethodNotSupportedRpcError(
             new Error(MethodNotSupportedRpcError.name),
@@ -210,9 +225,12 @@ export function xverse(parameters: UTXOConnectorParameters = {}) {
       if (!provider) {
         throw new ProviderNotFoundError()
       }
-      const accounts = await provider.request('getAddresses', {
-        purposes: ['payment'],
-      })
+      const accounts: GetAccountsResponse = await provider.request(
+        'getAddresses',
+        {
+          purposes: ['payment'],
+        }
+      )
       if (!accounts.result) {
         throw new UserRejectedRequestError({
           name: UserRejectedRequestError.name,

--- a/packages/core/src/actions/getAccountInfo.ts
+++ b/packages/core/src/actions/getAccountInfo.ts
@@ -1,0 +1,16 @@
+import type { Account, Chain, Client, Transport } from 'viem'
+import type { BtcAccount, UTXOWalletSchema } from '../clients/types.js'
+
+export async function getAddressInfo<
+  C extends Chain | undefined,
+  A extends Account | undefined = Account | undefined,
+>(client: Client<Transport, C, A, UTXOWalletSchema>): Promise<BtcAccount> {
+  const data = await client.request(
+    {
+      method: 'addressInfo',
+      params: [],
+    },
+    { dedupe: true }
+  )
+  return data
+}

--- a/packages/core/src/clients/types.ts
+++ b/packages/core/src/clients/types.ts
@@ -6,6 +6,10 @@ export type UTXOWalletSchema = readonly [
     Parameters: SignPsbtParameters
     ReturnType: SignPsbtReturnType
   },
+  {
+    Method: 'addressInfo'
+    ReturnType: BtcAccount
+  },
 ]
 
 export type SignPsbtParameters = {
@@ -42,7 +46,7 @@ export type UTXOWalletProvider = {
 
 export type BtcAccount = {
   address: string
-  addressType: 'p2tr' | 'p2wpkh' | 'p2wsh' | 'p2sh' | 'p2pkh'
+  addressType?: 'p2tr' | 'p2wpkh' | 'p2wsh' | 'p2sh' | 'p2pkh'
   publicKey: string
-  purpose: 'payment' | 'ordinals'
+  purpose?: 'payment' | 'ordinals'
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,6 +23,7 @@ export type {
   SendUTXOTransactionReturnType,
 } from './actions/sendUTXOTransaction.js'
 export { signPsbt } from './actions/signPsbt.js'
+export { getAddressInfo } from './actions/getAccountInfo.js'
 export { waitForTransaction } from './actions/waitForTransaction.js'
 export type {
   ReplacementReason,


### PR DESCRIPTION
I’ve submitted a PR to introduce a new method, getAddressInfo, which retrieves a wallet’s account data (e.g., publicKey, address, and optional addressType).

Why this change?
While using the package for wallet interactions (signing, connecting, etc.), I needed access to the user’s public key for building unsigned PSBTs. Since the current implementation didn’t provide this data, I added it to the accountInfo method while ensuring existing integrations remain unaffected.

Changes made:
1. Added getAddressInfo(client) request which take no params and return BtcAccount.

ex. 
`import { getAddressInfo } from '@bigmi/core';  
const accountInfo = await getAddressInfo(client);`
