### PR TITLE
fix: unisat wallet connector

### DIFF
--- a/packages/client/src/connectors/ctrl.ts
+++ b/packages/client/src/connectors/ctrl.ts
@@ -132,26 +132,7 @@ export function ctrl(parameters: UTXOConnectorParameters = {}) {
             return signedHex
           }
 
-          try {
-            // Pass the hex string directly to the wallet (it expects hex, not base64)
-            const psbt64 = hexToBase64(psbt)
-            const response = await this.signPsbt({
-              psbt: psbt64,
-              broadcast: Boolean(options.finalize),
-            })
-
-            if (response.status === 'success') {
-              const signedHex = base64ToHex(response.result.psbt)
-              return signedHex
-            }
-
-            throw new BaseError(response.error)
-
-            // The wallet returns a base64 string, so convert it back to hex
-          } catch (e) {
-            console.error('catching error in ctrl', e)
-            throw e
-          }
+          throw new BaseError(response.error)
         }
         default:
           throw new MethodNotSupportedRpcError(method)

--- a/packages/client/src/connectors/ctrl.ts
+++ b/packages/client/src/connectors/ctrl.ts
@@ -66,21 +66,13 @@ type CtrlConnectorProperties = {
 } & UTXOWalletProvider
 
 type CtrlBitcoinProvider = {
-  signPsbt(psbtHex: string, finalise?: boolean): Promise<string>
+  signPsbt({
+    psbt,
+  }: { psbt: string; broadcast: boolean; finalize: boolean }): Promise<
+    CtrlResponse<CtrlSignPsbtResult>
+  >
   requestAccounts(): Promise<Address[]>
   getAccounts(): Promise<Address[]>
-  request({
-    method,
-    params,
-  }: {
-    method: 'sign_psbt'
-    params: {
-      psbt: string
-      allowedSignHash: number
-      signInputs: Record<string, number[]>
-      broadcast: boolean
-    }
-  }): Promise<CtrlResponse<CtrlSignPsbtResult>>
   request({
     method,
     params,
@@ -129,33 +121,32 @@ export function ctrl(parameters: UTXOConnectorParameters = {}) {
         case 'signPsbt': {
           const { psbt, ...options } = params as SignPsbtParameters
 
-          const psbtBase64 = hexToBase64(psbt)
-          const signInputs = options.inputsToSign.reduce(
-            (signInputs, input) => {
-              if (!signInputs[input.address]) {
-                signInputs[input.address] = []
-              }
-              signInputs[input.address].push(...input.signingIndexes)
-              return signInputs
-            },
-            {} as Record<string, number[]>
-          )
-
-          const response = await this.request({
-            method: 'sign_psbt',
-            params: {
-              psbt: psbtBase64,
-              signInputs,
-              allowedSignHash: 1,
-              broadcast: Boolean(options.finalize),
-            },
-          })
-
-          if (response.status === 'success') {
-            return base64ToHex(response.result.psbt)
+          // Validate that psbt is provided
+          if (!psbt) {
+            throw new BaseError('PSBT parameter is required')
           }
 
-          throw new BaseError(response.error)
+          try {
+            // Pass the hex string directly to the wallet (it expects hex, not base64)
+            const psbt64 = hexToBase64(psbt)
+            const response = await this.signPsbt({
+              psbt: psbt64,
+              finalize: Boolean(options.finalize),
+              broadcast: Boolean(options.finalize),
+            })
+
+            if (response.status === 'success') {
+              const signedHex = base64ToHex(response.result.psbt)
+              return signedHex
+            }
+
+            throw new BaseError(response.error)
+
+            // The wallet returns a base64 string, so convert it back to hex
+          } catch (e) {
+            console.error('catching error in ctrl', e)
+            throw e
+          }
         }
         default:
           throw new MethodNotSupportedRpcError(method)

--- a/packages/client/src/connectors/unisat.ts
+++ b/packages/client/src/connectors/unisat.ts
@@ -184,7 +184,7 @@ export function unisat(parameters: UTXOConnectorParameters = {}) {
       try {
         const isConnected =
           shimDisconnect &&
-          // If shim exists in storage, connector is disconnected
+          // check storage to see if a connection exists already
           Boolean(await config.storage?.getItem(`${this.id}.connected`))
         return isConnected
       } catch {

--- a/packages/client/src/connectors/unisat.ts
+++ b/packages/client/src/connectors/unisat.ts
@@ -182,15 +182,11 @@ export function unisat(parameters: UTXOConnectorParameters = {}) {
     },
     async isAuthorized() {
       try {
-        const isDisconnected =
+        const isConnected =
           shimDisconnect &&
           // If shim exists in storage, connector is disconnected
-          (await config.storage?.getItem(`${this.id}.disconnected`))
-        if (isDisconnected) {
-          return false
-        }
-        const accounts = await withRetry(() => this.getAccounts())
-        return !!accounts.length
+          Boolean(await config.storage?.getItem(`${this.id}.connected`))
+        return isConnected
       } catch {
         return false
       }


### PR DESCRIPTION
When the unisat wallet is not connected, every function call activates the connect wallet popup.
Therefore, we shim the `isAuthorized` check logic to avoid this.
