### PR TITLE
ft(core): add missing names to transports

### DIFF
--- a/packages/core/src/transports/ankr/ankr.ts
+++ b/packages/core/src/transports/ankr/ankr.ts
@@ -20,6 +20,7 @@ export const ankr = (config?: AnkrConfig) => {
   return utxo(
     `https://rpc.ankr.com/premium-http/btc_blockbook/${config.apiKey}/api/v2`,
     {
+      name: 'Ankr API',
       key: 'ankr',
       methods,
       ...config,

--- a/packages/core/src/transports/blockchair/blockchair.ts
+++ b/packages/core/src/transports/blockchair/blockchair.ts
@@ -10,6 +10,7 @@ type BlockchairConfig = {
 
 export const blockchair = (config?: BlockchairConfig) =>
   utxo(config?.baseUrl || 'https://api.blockchair.com', {
+    name: 'Blockchair API',
     key: 'blockchair',
     includeChainToURL: true,
     methods: {

--- a/packages/core/src/transports/blockcypher/blockcypher.ts
+++ b/packages/core/src/transports/blockcypher/blockcypher.ts
@@ -10,6 +10,7 @@ type BlockcypherConfig = {
 
 export const blockcypher = (config?: BlockcypherConfig) =>
   utxo(config?.baseUrl || 'https://api.blockcypher.com/v1/btc/main', {
+    name: 'Blockcypher API',
     key: 'blockcypher',
     methods: {
       include: Object.keys(blockcypherMethods) as UTXOMethod[],

--- a/packages/core/src/transports/fallback.ts
+++ b/packages/core/src/transports/fallback.ts
@@ -194,7 +194,7 @@ export function fallback<const transports extends readonly Transport[]>(
               }
 
               collectedErrors.push({
-                transport: transport.config.key,
+                transport: transport.config.name,
                 error: err as Error,
                 attempt: i + 1,
               })

--- a/packages/core/src/transports/fallback.ts
+++ b/packages/core/src/transports/fallback.ts
@@ -194,7 +194,7 @@ export function fallback<const transports extends readonly Transport[]>(
               }
 
               collectedErrors.push({
-                transport: transport.config.name,
+                transport: transport.config.key,
                 error: err as Error,
                 attempt: i + 1,
               })

--- a/packages/core/src/transports/mempool/mempool.ts
+++ b/packages/core/src/transports/mempool/mempool.ts
@@ -9,6 +9,7 @@ type MempoolConfig = {
 
 export const mempool = (config?: MempoolConfig) =>
   utxo(config?.baseUrl || 'https://mempool.space/api', {
+    name: 'Mempool.space API',
     key: 'mempool',
     methods: {
       include: Object.keys(mempoolMethods) as UTXOMethod[],


### PR DESCRIPTION
This PR adds names to our custom HTTP transports for better reporting during error collection from the fallback transport.

### Before
All transports below were named `UTXO HTTP API`

<img width="2348" height="844" alt="image (9)" src="https://github.com/user-attachments/assets/4e02837b-889c-4e61-859b-b1acc0aa0e05" />

### After
<img width="805" height="259" alt="Screenshot 2025-07-16 at 3 09 44 PM" src="https://github.com/user-attachments/assets/0b22e2f7-1d85-412b-8141-51f55d40e18e" />

