### PR TITLE
fix(connectors): remove retry logic when checking if app isAuthorized

### DIFF
--- a/packages/client/src/connectors/binance.ts
+++ b/packages/client/src/connectors/binance.ts
@@ -186,15 +186,11 @@ export function binance(parameters: UTXOConnectorParameters = {}) {
     },
     async isAuthorized() {
       try {
-        const isDisconnected =
+        const isConnected =
           shimDisconnect &&
-          // If shim exists in storage, connector is disconnected
-          (await config.storage?.getItem(`${this.id}.disconnected`))
-        if (isDisconnected) {
-          return false
-        }
-        const accounts = await withRetry(() => this.getAccounts())
-        return !!accounts.length
+          // check storage to see if a connection exists already
+          Boolean(await config.storage?.getItem(`${this.id}.connected`))
+        return isConnected
       } catch {
         return false
       }

--- a/packages/client/src/connectors/bitget.ts
+++ b/packages/client/src/connectors/bitget.ts
@@ -187,15 +187,11 @@ export function bitget(parameters: UTXOConnectorParameters = {}) {
     },
     async isAuthorized() {
       try {
-        const isDisconnected =
+        const isConnected =
           shimDisconnect &&
-          // If shim exists in storage, connector is disconnected
-          (await config.storage?.getItem(`${this.id}.disconnected`))
-        if (isDisconnected) {
-          return false
-        }
-        const accounts = await withRetry(() => this.getAccounts())
-        return !!accounts.length
+          // check storage to see if a connection exists already
+          Boolean(await config.storage?.getItem(`${this.id}.connected`))
+        return isConnected
       } catch {
         return false
       }

--- a/packages/client/src/connectors/magicEden.ts
+++ b/packages/client/src/connectors/magicEden.ts
@@ -165,15 +165,11 @@ export function magicEden(parameters: UTXOConnectorParameters = {}) {
     },
     async isAuthorized() {
       try {
-        const isDisconnected =
+        const isConnected =
           shimDisconnect &&
-          // If shim exists in storage, connector is disconnected
-          (await config.storage?.getItem(`${this.id}.disconnected`))
-        if (isDisconnected) {
-          return false
-        }
-        const accounts = await withRetry(() => this.getAccounts())
-        return !!accounts.length
+          // check storage to see if a connection exists already
+          Boolean(await config.storage?.getItem(`${this.id}.connected`))
+        return isConnected
       } catch {
         return false
       }

--- a/packages/client/src/connectors/okx.ts
+++ b/packages/client/src/connectors/okx.ts
@@ -194,15 +194,11 @@ export function okx(parameters: UTXOConnectorParameters = {}) {
     },
     async isAuthorized() {
       try {
-        const isDisconnected =
+        const isConnected =
           shimDisconnect &&
-          // If shim exists in storage, connector is disconnected
-          (await config.storage?.getItem(`${this.id}.disconnected`))
-        if (isDisconnected) {
-          return false
-        }
-        const accounts = await withRetry(() => this.getAccounts())
-        return !!accounts.length
+          // check storage to see if a connection exists already
+          Boolean(await config.storage?.getItem(`${this.id}.connected`))
+        return isConnected
       } catch {
         return false
       }

--- a/packages/client/src/connectors/onekey.ts
+++ b/packages/client/src/connectors/onekey.ts
@@ -178,15 +178,11 @@ export function onekey(parameters: UTXOConnectorParameters = {}) {
     },
     async isAuthorized() {
       try {
-        const isDisconnected =
+        const isConnected =
           shimDisconnect &&
-          // If shim exists in storage, connector is disconnected
-          (await config.storage?.getItem(`${this.id}.disconnected`))
-        if (isDisconnected) {
-          return false
-        }
-        const accounts = await withRetry(() => this.getAccounts())
-        return !!accounts.length
+          // check storage to see if a connection exists already
+          Boolean(await config.storage?.getItem(`${this.id}.connected`))
+        return isConnected
       } catch {
         return false
       }


### PR DESCRIPTION
This PR fixes a user problem where all unisat based connectors calls `getAccounts()` repeatedly inside the `isAuthorized()`.

## Problem
1. `getAccounts()` triggers the connect pop up if the wallet is not connected, so this is not a great logic to check if a user is already connected.
2. we are calling `getAccounts` using a retry logic.

## Solution
1. Remove the `withRetry` logic, to remove the repeated calls.
2. Since we mange the connection state in storage in `connect` and `disconnect`, we don't need to make the redundant call to `getAccounts`, as it will be called again during a reconnection.
