### PR TITLE
fix(blockchair): handle zero balance addresses edge case

### DIFF
--- a/packages/core/src/transports/blockchair/blockchair.spec.ts
+++ b/packages/core/src/transports/blockchair/blockchair.spec.ts
@@ -57,7 +57,7 @@ describe('Blockchair Transport', () => {
       expect(balance).toBeTypeOf('bigint')
     })
 
-    it('should throw error for non-existent address', async () => {
+    it('should return 0n for a non-existent or a zero balance address', async () => {
       if (USE_MOCK) {
         vi.spyOn(global, 'fetch').mockResolvedValue(
           createMockResponse(
@@ -70,7 +70,7 @@ describe('Blockchair Transport', () => {
         '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNaNUIBNSUENopnoidsacn'
       await expect(
         getBalance(publicClient, { address: nonExistentAddress })
-      ).rejects.toThrow()
+      ).resolves.toEqual(0n)
     })
   })
 

--- a/packages/core/src/transports/blockchair/getBalance.ts
+++ b/packages/core/src/transports/blockchair/getBalance.ts
@@ -19,11 +19,8 @@ export const getBalance: RpcMethodHandler<'getBalance'> = async (
     url: apiUrl,
     fetchOptions: { method: 'GET' },
   })) as unknown as BlockchairResponse<BlockchairAddressBalanceData>
-  if (
-    response.data[address] === undefined ||
-    response.context.error ||
-    response.context?.code !== 200
-  ) {
+
+  if (response.context.error || response.context?.code !== 200) {
     return {
       error: {
         code:
@@ -34,6 +31,13 @@ export const getBalance: RpcMethodHandler<'getBalance'> = async (
       },
     }
   }
+
+  if (response.data[address] === undefined) {
+    return {
+      result: 0n,
+    }
+  }
+
   return {
     result: BigInt(response.data[address]),
   }

--- a/packages/core/src/transports/blockchair/getUTXOs.ts
+++ b/packages/core/src/transports/blockchair/getUTXOs.ts
@@ -1,3 +1,4 @@
+import { BaseError } from '../../errors/base.js'
 import { RpcRequestError } from '../../errors/request.js'
 import { RpcErrorCode } from '../../errors/rpc.js'
 import { InsufficientUTXOBalanceError } from '../../errors/utxo.js'
@@ -90,11 +91,18 @@ export const getUTXOs: RpcMethodHandler<'getUTXOs'> = async (
   }
 
   if (minValue) {
-    const { result: balance } = await getBalance(
+    const { error, result: balance = 0n } = await getBalance(
       client,
       { baseUrl, apiKey },
       { address }
     )
+
+    if (error) {
+      throw new BaseError('Error fetching balance', {
+        cause: error,
+      })
+    }
+
     if (minValue > Number(balance)) {
       throw new InsufficientUTXOBalanceError({
         minValue,


### PR DESCRIPTION
## What was done?
When an address has a zero balance, they blockchair API returns an empty data object causing the `getBalance` to return an error , which in turn breaks `getUTXO`

**Address with balance**
<img width="735" height="657" alt="Screenshot 2025-09-26 at 14 24 51" src="https://github.com/user-attachments/assets/1bcbee3f-899e-4968-a807-845dd741c22a" />


**Zero Balance address**

<img width="641" height="694" alt="Screenshot 2025-09-26 at 14 24 46" src="https://github.com/user-attachments/assets/40e9ba7f-31d1-46f6-984a-43546e6397ee" />

To fix this, 0 is returned in `getBalance` when the data object is empty, and in `getUTXOs` a default value of balance is set to 0.
