### PR TITLE
chore: change hardcoded numeric chain ID with the ChainId enum

### DIFF
--- a/docs/core/config.md
+++ b/docs/core/config.md
@@ -86,10 +86,10 @@ const client = createClient({
 We only have a chain definition for bitcoin mainnet, custom chains can be created using the `defineChain` util.
 
 ```typescript
-import { defineChain } from '@bigmi/core'
+import { defineChain, ChainId } from '@bigmi/core'
 
 const testnet4 = defineChain({
-  id: 20000000000004,
+  id: ChainId.BITCOIN_TESTNET4,
   name: 'Bitcoin Testnet4',
   nativeCurrency: { name: 'Bitcoin', symbol: 'BTC', decimals: 8 },
   rpcUrls: {


### PR DESCRIPTION
The docs example caused a TypeScript error: Type 'number' is not assignable to type 'ChainId'

Updated code to import ChainId from @bigmi/core and use ChainId.BITCOIN_TESTNET4 for the id field instead of a raw number. This makes the defineChain call type-safe and consistent with the core library’s expected ChainId type.

