### PR TITLE
Docs bug: useAccount() no longer returns address at top level

### DIFF
--- a/docs/react/hooks.md
+++ b/docs/react/hooks.md
@@ -26,14 +26,14 @@ import { useAccount, useConnect } from '@bigmi/react'
 
 function Component() {
   // Property 'address' does not exist on type 'UseAccountReturnType<Config>'.ts(2339)
-  const { address, isConnected, connector: activeWallet } = useAccount()
+  const { account , isConnected, connector: activeWallet } = useAccount()
   const { connect, connectors } = useConnect()
   
   return (
     <div>
       {isConnected ? (
         <>
-          <p>Connected: {address}</p>
+          <p>Connected: {account.address}</p>
           <button onClick={() => activeWallet.disconnect()}>Disconnect</button>
         </>
       ) : (


### PR DESCRIPTION
The documentation for useAccount() is outdated. It still demonstrates accessing the address property directly from the hook’s return value, but the latest version of the library no longer exposes address at the top level. Instead, useAccount() now returns an object containing account and accounts, without a direct address field.

As a result, following the current example in the docs produces a TypeScript error:

Property 'address' does not exist on type 'UseAccountReturnType<Config>'.ts(2339)
