### PR TITLE
fix(blockchair-getXpubAddresses): return empty data for valid keys with empty addresses

### DIFF
--- a/packages/core/src/transports/blockchair/blockchair.spec.ts
+++ b/packages/core/src/transports/blockchair/blockchair.spec.ts
@@ -307,18 +307,20 @@ describe('Blockchair Transport', () => {
         expect(response.addresses.length).toBe(3)
       } else {
         expect(response.balance).toBeGreaterThanOrEqual(0n)
-        expect(response.addresses.length).toBeGreaterThan(0)
+        expect(response.addresses.length).toBeGreaterThanOrEqual(0)
       }
 
       expect(response.addresses).toBeDefined()
       expect(Array.isArray(response.addresses)).toBe(true)
 
-      expect(response.addresses[0]).toMatchObject({
-        address: expect.any(String),
-        balance: expect.any(BigInt),
-        path: expect.any(String),
-        scriptHex: expect.any(String),
-      })
+      if (response.addresses[0]) {
+        expect(response.addresses[0]).toMatchObject({
+          address: expect.any(String),
+          balance: expect.any(BigInt),
+          path: expect.any(String),
+          scriptHex: expect.any(String),
+        })
+      }
     })
   })
 })

--- a/packages/core/src/transports/blockchair/getXPubAddresses.ts
+++ b/packages/core/src/transports/blockchair/getXPubAddresses.ts
@@ -19,11 +19,7 @@ export const getXPubAddresses: RpcMethodHandler<'getXPubAddresses'> = async (
     fetchOptions: { method: 'GET' },
   })) as unknown as BlockchairResponse<BlockchairXpubResponse>
 
-  if (
-    response.data[xPubKey] === undefined ||
-    response.context.error ||
-    response.context?.code !== 200
-  ) {
+  if (response.context.error || response.context?.code !== 200) {
     return {
       error: {
         code:
@@ -31,6 +27,15 @@ export const getXPubAddresses: RpcMethodHandler<'getXPubAddresses'> = async (
             ? RpcErrorCode.ACCESS_DENIED
             : RpcErrorCode.MISC_ERROR,
         message: response.context?.error,
+      },
+    }
+  }
+
+  if (response.data[xPubKey] === undefined) {
+    return {
+      result: {
+        balance: 0n,
+        addresses: [],
       },
     }
   }


### PR DESCRIPTION
The getXPubAddresses action on the blockchair transport now returns an empty response for xpub keys that are valid but have no addresses.