### PR TITLE
chore(changeset): set updateInternalDependencies to patch

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,7 +6,7 @@
   "fixed": [],
   "linked": [],
   "baseBranch": "main",
-  "updateInternalDependencies": "minor",
+  "updateInternalDependencies": "patch",
   "ignore": [],
   "snapshot": { "prereleaseTemplate": "{tag}" }
 }

--- a/.claude/skills/changeset/SKILL.md
+++ b/.claude/skills/changeset/SKILL.md
@@ -58,7 +58,7 @@ real gate). Your job here is to write a correct changeset for the work in progre
 ## Key rules (full detail in `references/`)
 
 - **Only declare packages you intentionally changed.** Internal dependents re-release
-  automatically (`updateInternalDependencies: minor`); authoring changesets for them
+  automatically (`updateInternalDependencies: patch`); authoring changesets for them
   double-counts and produces noisy changelogs.
 - **Skip** docs-only, chore-only, test-only, and private-package-only changes. For a
   deliberately release-less change, `pnpm changeset --empty`.

--- a/.claude/skills/changeset/references/bump-rules.md
+++ b/.claude/skills/changeset/references/bump-rules.md
@@ -28,7 +28,7 @@ There are no private/ignored workspace packages (`.changeset/config.json` `ignor
   ↑ @bigmi/react    (depends on client AND core)
 ```
 
-Internal deps use `workspace:^`. With `updateInternalDependencies: minor`, bumping a
+Internal deps use `workspace:^`. With `updateInternalDependencies: patch`, bumping a
 package **re-releases its dependents automatically**. So:
 
 - Changed `@bigmi/core` only → declare a changeset for **just** `@bigmi/core`; `client` and


### PR DESCRIPTION
Sets `updateInternalDependencies` back to the Changesets default (`patch`) so **any** bump to a workspace package — including a patch — re-releases its internal dependents, keeping their pinned (`workspace:*`/`workspace:^`) versions current instead of lagging until the next minor.

Updates the CLAUDE.md / changeset-skill references to match. No code changes.