### PR TITLE
chore(deps): pin internal @bigmi/* deps with workspace:* (lockstep releases)

### DIFF
--- a/.claude/skills/changeset/references/bump-rules.md
+++ b/.claude/skills/changeset/references/bump-rules.md
@@ -28,8 +28,9 @@ There are no private/ignored workspace packages (`.changeset/config.json` `ignor
   ↑ @bigmi/react    (depends on client AND core)
 ```
 
-Internal deps use `workspace:^`. With `updateInternalDependencies: patch`, bumping a
-package **re-releases its dependents automatically**. So:
+Internal deps use `workspace:*` (exact pins), so bumping a package **re-releases its
+dependents automatically** — any new version leaves the exact pin, forcing Changesets to
+re-version every dependent. So:
 
 - Changed `@bigmi/core` only → declare a changeset for **just** `@bigmi/core`; `client` and
   `react` bump on their own.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Releases use **[Changesets](https://github.com/changesets/changesets)** (indepen
 
 **Flow (all automated on push to `main` via `publish.yaml`):**
 1. PRs land with changeset files.
-2. Changesets opens/updates a **"chore: version packages"** PR that consumes the changesets, bumps versions, refreshes internal `workspace:^` ranges, and writes per-package `CHANGELOG.md`.
+2. Changesets opens/updates a **"chore: version packages"** PR that consumes the changesets, bumps versions, refreshes internal `workspace:*` pins, and writes per-package `CHANGELOG.md`.
 3. Merging that PR triggers `release`, which runs `pnpm changeset:publish` and creates GitHub Releases.
 4. On a successful publish that includes `@bigmi/react`, the **Linear "Bigmi"** pipeline is synced (issues attached + release completed).
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -39,7 +39,7 @@
     "hooks"
   ],
   "dependencies": {
-    "@bigmi/core": "workspace:^",
+    "@bigmi/core": "workspace:*",
     "eventemitter3": "^5.0.4",
     "zustand": "^5.0.14"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -39,8 +39,8 @@
     "hooks"
   ],
   "dependencies": {
-    "@bigmi/client": "workspace:^",
-    "@bigmi/core": "workspace:^"
+    "@bigmi/client": "workspace:*",
+    "@bigmi/core": "workspace:*"
   },
   "devDependencies": {
     "cpy-cli": "^7.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,7 +54,7 @@ importers:
   packages/client:
     dependencies:
       '@bigmi/core':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../core
       '@tanstack/query-core':
         specifier: '>=5.68.0'
@@ -116,10 +116,10 @@ importers:
   packages/react:
     dependencies:
       '@bigmi/client':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../client
       '@bigmi/core':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../core
       '@tanstack/react-query':
         specifier: '>=5.68.0'


### PR DESCRIPTION
Switches @bigmi/react and @bigmi/client internal deps from `workspace:^` to `workspace:*` (matching the widget/sdk convention — both already use `workspace:*` everywhere).

**Why:** with `workspace:^`, a *patch* bump to `@bigmi/core` did **not** re-release `@bigmi/react` — react's published `^0.8.0` range already accepted `0.8.1`, so Changesets skipped it (see #56). With `workspace:*` the published pin is exact, so any `@bigmi/core`/`@bigmi/client` bump re-releases its dependents, keeping all `@bigmi/*` packages in sync.

**Verified** with `changeset version` in a throwaway worktree: a `@bigmi/core` *patch* changeset bumps core → 0.8.1, client → 0.8.1, **and react → 0.8.1** (under `workspace:^` react stayed at 0.8.0).

Includes the lockfile specifier update and CLAUDE.md / changeset-skill doc fixes.