### PR TITLE
fix(client): drop stale connections on reconnect

### DIFF
--- a/.changeset/reconnect-drop-stale-connections.md
+++ b/.changeset/reconnect-drop-stale-connections.md
@@ -1,0 +1,5 @@
+---
+'@bigmi/client': patch
+---
+
+Fix `reconnect` leaving a stale connection stub after reload. On the first successful reconnection the connections map is now rebuilt from scratch instead of copying the map rehydrated from storage under the previous session's connector uid, and `current` points at the freshly reconnected connector. When no connector reconnects, `connections` and `current` are reset alongside `status: 'disconnected'`. Matches wagmi's behavior.

--- a/packages/client/src/actions/reconnect.ts
+++ b/packages/client/src/actions/reconnect.ts
@@ -75,6 +75,7 @@ export async function reconnect(
   // Add this before the connectionPromises mapping
   const processedProviders = new Set()
 
+  // Connectors run in parallel, so keep this check-and-set synchronous
   let connected = false
 
   // Try to connect to each connector in parallel
@@ -118,23 +119,28 @@ export async function reconnect(
       connector.emitter.on('change', config._internal.events.change)
       connector.emitter.on('disconnect', config._internal.events.disconnect)
 
-      // Update config state immediately when this connector succeeds
+      // Update config state immediately when this connector succeeds.
+      // The first success replaces the map rehydrated from storage, since those
+      // entries are keyed by the previous session's uids.
+      const isFirst = !connected
+      connected = true
+
       config.setState((x) => {
-        const connections = new Map(connected ? x.connections : new Map())
+        const connections: Map<string, Connection> = isFirst
+          ? new Map()
+          : new Map(x.connections)
         connections.set(connector.uid, {
           accounts: data.accounts as readonly [Account, ...Account[]],
           chainId: data.chainId,
           connector,
         })
 
-        const next = {
+        return {
           ...x,
           connections,
-          current: connected ? x.current : connector.uid,
-          status: 'connected' as const,
+          current: isFirst ? connector.uid : x.current,
+          status: 'connected',
         }
-        connected = true
-        return next
       })
 
       return { connector, data }
@@ -158,7 +164,7 @@ export async function reconnect(
     }
   }
 
-  if (connections.length === 0) {
+  if (!connected) {
     config.setState((x) => ({
       ...x,
       connections: new Map(),

--- a/packages/client/src/actions/reconnect.ts
+++ b/packages/client/src/actions/reconnect.ts
@@ -75,6 +75,8 @@ export async function reconnect(
   // Add this before the connectionPromises mapping
   const processedProviders = new Set()
 
+  let connected = false
+
   // Try to connect to each connector in parallel
   const connectionPromises = sorted.map(async (connector) => {
     try {
@@ -118,19 +120,21 @@ export async function reconnect(
 
       // Update config state immediately when this connector succeeds
       config.setState((x) => {
-        const connections = new Map(x.connections)
+        const connections = new Map(connected ? x.connections : new Map())
         connections.set(connector.uid, {
           accounts: data.accounts as readonly [Account, ...Account[]],
           chainId: data.chainId,
           connector,
         })
 
-        return {
+        const next = {
           ...x,
           connections,
-          current: x.current || connector.uid, // Set as current if none exists
-          status: 'connected',
+          current: connected ? x.current : connector.uid,
+          status: 'connected' as const,
         }
+        connected = true
+        return next
       })
 
       return { connector, data }
@@ -157,6 +161,8 @@ export async function reconnect(
   if (connections.length === 0) {
     config.setState((x) => ({
       ...x,
+      connections: new Map(),
+      current: null,
       status: 'disconnected',
     }))
   }


### PR DESCRIPTION
## Problem

`reconnect` never removes connections rehydrated from storage under the previous session's connector `uid`. On every reload the successful-reconnection path did `new Map(x.connections)`, copying the rehydrated map, so the stale stub survived and `current` could keep pointing at a dead connector.

Fixes #65

## Fix

Match wagmi's behavior:

- Introduce a shared `connected` flag (reconnect attempts run in parallel via `Promise.allSettled`). The **first** successful reconnection rebuilds the connections map from scratch (`new Map(connected ? x.connections : new Map())`) and sets `current: connected ? x.current : connector.uid`, so the fresh map replaces the rehydrated one and `current` points at the connector that actually reconnected. Later successes in the same run append to it.
- When nothing reconnects, reset `connections` and `current` alongside `status: 'disconnected'` instead of leaving the stale map in place.

## Notes

- Includes a `@bigmi/client` patch changeset.
- `pnpm check`, `pnpm check:types`, `pnpm check:circular-deps`, `pnpm knip:check`, and `pnpm test` all pass locally (pre-commit / pre-push hooks).