### PR TITLE
fix(client): keep concurrent connect() alive across reconnect

### DIFF
--- a/.changeset/reconnect-preserve-concurrent-connect.md
+++ b/.changeset/reconnect-preserve-concurrent-connect.md
@@ -1,0 +1,5 @@
+---
+'@bigmi/client': patch
+---
+
+Stop `reconnect` from clearing a connection established by a concurrent `connect()` call. Reconnect runs on mount and polls for a wallet provider for up to 5s, so a user can connect manually while it is still in flight; the no-connector-reconnected reset now only applies when the store is still in the `reconnecting`/`connecting` state reconnect put it in. Matches wagmi's behavior.

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -14,7 +14,8 @@
     "clean": "rm -rf dist",
     "check:types": "tsc --noEmit",
     "check:circular-deps": "madge --circular $(find ./src -name '*.ts' -o -name '*.tsx')",
-    "check:circular-deps-graph": "madge --circular $(find ./src -name '*.ts' -o -name '*.tsx') --image graph.svg"
+    "check:circular-deps-graph": "madge --circular $(find ./src -name '*.ts' -o -name '*.tsx') --image graph.svg",
+    "test": "vitest"
   },
   "author": "Eugene Chybisov <eugene@li.finance>",
   "homepage": "https://github.com/lifinance/bigmi",
@@ -48,7 +49,8 @@
   "devDependencies": {
     "cpy-cli": "^7.0.0",
     "madge": "^8.0.0",
-    "typescript": "^7.0.2"
+    "typescript": "^7.0.2",
+    "vitest": "^4.1.10"
   },
   "peerDependencies": {
     "@tanstack/query-core": ">=5.68.0"

--- a/packages/client/src/actions/reconnect.spec.ts
+++ b/packages/client/src/actions/reconnect.spec.ts
@@ -1,0 +1,171 @@
+import {
+  type Account,
+  type Address,
+  AddressType,
+  bitcoin,
+  ChainId,
+} from '@bigmi/core'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createConfig } from '../factories/createConfig.js'
+import { createConnector } from '../factories/createConnector.js'
+import { createStorage } from '../factories/createStorage.js'
+import type { Connection } from '../types/connection.js'
+import type { CreateConnectorFn } from '../types/connector.js'
+import { connect } from './connect.js'
+import { reconnect } from './reconnect.js'
+
+const address = 'bc1q8h8s4zd9y0lkrx334aqnj4ykqs220ss735a3gh' as Address
+
+const account: Account = {
+  address,
+  addressType: AddressType.p2wpkh,
+  publicKey:
+    '03cbaedc26f03fd3ba02fc936f338e980c9e2172c5e23128877ed46827e935296f',
+  purpose: 'payment',
+}
+
+type MockConnectorParameters = {
+  id: string
+  /** Resolves the authorization check. Defaults to authorized. */
+  isAuthorized?: () => Promise<boolean>
+}
+
+function mockConnector({
+  id,
+  isAuthorized = async () => true,
+}: MockConnectorParameters): CreateConnectorFn {
+  return createConnector(() => ({
+    id,
+    name: id,
+    type: 'UTXO',
+    async connect() {
+      return { accounts: [account], chainId: ChainId.BITCOIN_MAINNET }
+    },
+    async disconnect() {},
+    async getAccounts() {
+      return [account]
+    },
+    async getChainId() {
+      return ChainId.BITCOIN_MAINNET
+    },
+    async getProvider() {
+      // Distinct object per connector so reconnect's provider dedup
+      // does not collapse them into one.
+      return { id }
+    },
+    isAuthorized,
+    onAccountsChanged() {},
+    onChainChanged() {},
+    onDisconnect() {},
+  }))
+}
+
+function createTestConfig(connectors: readonly CreateConnectorFn[]) {
+  const storedValues = new Map<string, string>()
+
+  return createConfig({
+    chains: [bitcoin],
+    client: () => ({}) as any,
+    connectors,
+    multiInjectedProviderDiscovery: false,
+    storage: createStorage({
+      key: 'test',
+      storage: {
+        getItem: (key) => storedValues.get(key),
+        removeItem: (key) => {
+          storedValues.delete(key)
+        },
+        setItem: (key, value) => {
+          storedValues.set(key, value)
+        },
+      },
+    }),
+  })
+}
+
+/**
+ * Mimics what `persist` rehydrates: a connection keyed by the previous
+ * session's uid, whose connector is a plain object with no methods.
+ */
+function seedRehydratedConnection(config: ReturnType<typeof createTestConfig>) {
+  const staleUid = 'stale-uid-from-previous-session'
+  const staleConnection = {
+    accounts: [account],
+    chainId: ChainId.BITCOIN_MAINNET,
+    connector: { id: 'mock', name: 'mock', type: 'UTXO', uid: staleUid },
+  } as unknown as Connection
+
+  config.setState((x) => ({
+    ...x,
+    connections: new Map([[staleUid, staleConnection]]),
+    current: staleUid,
+    status: 'reconnecting',
+  }))
+
+  return staleUid
+}
+
+describe('reconnect', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('replaces the connection rehydrated under the previous session uid', async () => {
+    const config = createTestConfig([mockConnector({ id: 'mock' })])
+    const staleUid = seedRehydratedConnection(config)
+
+    await reconnect(config)
+
+    const liveUid = config.connectors[0].uid
+    expect(config.state.connections.has(staleUid)).toBe(false)
+    expect(config.state.connections.size).toBe(1)
+    expect(config.state.current).toBe(liveUid)
+    expect(config.state.status).toBe('connected')
+    // The live entry carries a real connector, not a serialized stub.
+    expect(
+      typeof config.state.connections.get(liveUid)?.connector.connect
+    ).toBe('function')
+  })
+
+  it('resets connections and current when nothing reconnects', async () => {
+    const config = createTestConfig([
+      mockConnector({ id: 'mock', isAuthorized: async () => false }),
+    ])
+    seedRehydratedConnection(config)
+
+    const connections = await reconnect(config)
+
+    expect(connections).toHaveLength(0)
+    expect(config.state.connections.size).toBe(0)
+    expect(config.state.current).toBeNull()
+    expect(config.state.status).toBe('disconnected')
+  })
+
+  it('keeps a connection established by connect() while reconnect is in flight', async () => {
+    // Holds reconnect open until we release it, so `connect()` lands first.
+    let releaseAuthorization: (isAuthorized: boolean) => void = () => {}
+    const authorizationCheck = new Promise<boolean>((resolve) => {
+      releaseAuthorization = resolve
+    })
+
+    const config = createTestConfig([
+      mockConnector({ id: 'slow', isAuthorized: () => authorizationCheck }),
+      // Never reconnects on its own — only connected explicitly below.
+      mockConnector({ id: 'manual', isAuthorized: async () => false }),
+    ])
+
+    const reconnectPromise = reconnect(config)
+    await vi.waitFor(() => expect(config.state.status).toBe('connecting'))
+
+    const manualConnector = config.connectors[1]
+    await connect(config, { connector: manualConnector })
+    expect(config.state.current).toBe(manualConnector.uid)
+
+    releaseAuthorization(false)
+    await reconnectPromise
+
+    expect(config.state.connections.has(manualConnector.uid)).toBe(true)
+    expect(config.state.current).toBe(manualConnector.uid)
+    expect(config.state.status).toBe('connected')
+  })
+})

--- a/packages/client/src/actions/reconnect.ts
+++ b/packages/client/src/actions/reconnect.ts
@@ -164,7 +164,15 @@ export async function reconnect(
     }
   }
 
-  if (!connected) {
+  // Only reset if the store is still in the state reconnect put it in. A
+  // `connect()` call can land while reconnect is in flight — reconnect runs on
+  // mount and polls for a provider for up to 5s — and its connection must not
+  // be wiped here.
+  const isStillReconnecting =
+    config.state.status === 'reconnecting' ||
+    config.state.status === 'connecting'
+
+  if (!connected && isStillReconnecting) {
     config.setState((x) => ({
       ...x,
       connections: new Map(),

--- a/packages/client/src/connectors/unisat.spec.ts
+++ b/packages/client/src/connectors/unisat.spec.ts
@@ -1,0 +1,90 @@
+import { type Address, bitcoin, ChainId } from '@bigmi/core'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createEmitter } from '../factories/createEmitter.js'
+import { createStorage } from '../factories/createStorage.js'
+import type { ConnectorEventMap } from '../types/connector.js'
+import { UnisatBitcoinChainEnum, unisat } from './unisat.js'
+
+const address = 'bc1q8h8s4zd9y0lkrx334aqnj4ykqs220ss735a3gh' as Address
+const publicKey =
+  '03cbaedc26f03fd3ba02fc936f338e980c9e2172c5e23128877ed46827e935296f'
+
+function createProvider(accounts: Address[] = [address]) {
+  return {
+    addListener: vi.fn(),
+    getAccounts: vi.fn(async () => accounts),
+    getChain: vi.fn(async () => ({
+      enum: UnisatBitcoinChainEnum.BITCOIN_MAINNET,
+      name: 'Bitcoin Mainnet',
+      network: 'livenet' as const,
+    })),
+    getPublicKey: vi.fn(async () => publicKey),
+    removeListener: vi.fn(),
+    requestAccounts: vi.fn(async () => accounts),
+    signPsbt: vi.fn(),
+    switchChain: vi.fn(),
+  }
+}
+
+async function createTestConnector(
+  provider: ReturnType<typeof createProvider>
+) {
+  vi.stubGlobal('window', { unisat: provider })
+
+  const storedValues = new Map<string, string>()
+  const storage = createStorage({
+    key: 'test',
+    storage: {
+      getItem: vi.fn((key) => storedValues.get(key)),
+      removeItem: vi.fn((key) => {
+        storedValues.delete(key)
+      }),
+      setItem: vi.fn((key, value) => {
+        storedValues.set(key, value)
+      }),
+    },
+  })
+  await storage.setItem('unisat.connected', true)
+
+  return unisat()({
+    chains: [bitcoin],
+    emitter: createEmitter<ConnectorEventMap>('test'),
+    storage,
+  })
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('unisat connector', () => {
+  it('reconnects through passive account access', async () => {
+    const provider = createProvider()
+    const connector = await createTestConnector(provider)
+
+    expect(await connector.isAuthorized()).toBe(true)
+    const result = await connector.connect({ isReconnecting: true })
+
+    expect(provider.requestAccounts).not.toHaveBeenCalled()
+    expect(provider.getAccounts).toHaveBeenCalled()
+    expect(result.accounts[0]?.address).toBe(address)
+    expect(result.chainId).toBe(ChainId.BITCOIN_MAINNET)
+  })
+
+  it('requests account access for an explicit connection', async () => {
+    const provider = createProvider()
+    const connector = await createTestConnector(provider)
+
+    await connector.connect()
+
+    expect(provider.requestAccounts).toHaveBeenCalledOnce()
+  })
+
+  it('is not authorized when the extension exposes no accounts', async () => {
+    const provider = createProvider([])
+    const connector = await createTestConnector(provider)
+
+    expect(await connector.isAuthorized()).toBe(false)
+    expect(provider.requestAccounts).not.toHaveBeenCalled()
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@8.1.0(@types/node@26.1.1)(jiti@2.7.0)(yaml@2.9.0))
 
   packages/core:
     dependencies:


### PR DESCRIPTION
Follow-up to #66 / #67.

## Problem

`reconnect` runs on mount and polls each connector for a provider for up to 5s (`retryUntil`, 5000ms), so it is commonly in flight for several seconds on every page load. A user can complete a manual `connect()` inside that window.

When no connector reconnected, the tail reset fired unconditionally and wiped that fresh connection:

```ts
if (!connected) {
  config.setState((x) => ({ ...x, connections: new Map(), current: null, status: 'disconnected' }))
}
```

The user ends up disconnected immediately after successfully connecting.

## Fix

Gate the reset on the store still being in the state reconnect put it in, so it only clears what reconnect itself owns:

```ts
const isStillReconnecting =
  config.state.status === 'reconnecting' || config.state.status === 'connecting'

if (!connected && isStillReconnecting) { /* reset */ }
```

This is [wagmi's guard](https://github.com/wevm/wagmi/blob/main/packages/core/src/actions/reconnect.ts) (*"Prevent overwriting connected status from race condition"*), the one piece of that block #66 did not port. Both interleavings are safe: if `connect()` finishes first the status is `connected` and the reset is skipped; if it is still in flight the status is `connecting`, the reset clears an empty map, and `connect()` then writes its own state on top.

## Tests

Restores the `@bigmi/client` vitest setup and `unisat.spec.ts` that were added and then removed within #67 — the specs pass unchanged against the merged code. Adds `reconnect.spec.ts` covering:

- the stale rehydrated connection being replaced (regression test for #65)
- `connections`/`current` reset when nothing reconnects
- **the race above** — a deferred authorization check holds reconnect open while `connect()` lands; verified to fail without the guard and pass with it

`pnpm test` now covers `@bigmi/client` as well: 6 passed (client), 32 passed / 1 skipped (core).

## Considered and rejected

Making `current` deterministic under parallelism (first-to-*resolve* wins rather than first in `sorted` order, so `recentConnectorId` priority is best-effort). Both implementations — rank tracking shared across parallel tasks, or a post-hoc re-pick — add a second synchronicity invariant to already-subtle code, and the loser is still a live connector. Not worth the complexity; happy to revisit if multi-wallet users report it.

## Validation

`pnpm check`, `pnpm check:types`, `pnpm check:circular-deps`, `pnpm knip:check`, `pnpm test` all pass.